### PR TITLE
Allow specifying in which dimensions splash water bottles are allowed to extinguish entities

### DIFF
--- a/src/main/java/com/suppergerrie2/betterwatersplash/BetterWaterSplash.java
+++ b/src/main/java/com/suppergerrie2/betterwatersplash/BetterWaterSplash.java
@@ -8,7 +8,10 @@ import net.minecraft.world.item.alchemy.*;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.event.entity.ProjectileImpactEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 import java.util.List;
 
@@ -18,10 +21,17 @@ public class BetterWaterSplash {
 
     public static final String MOD_ID = "sbetterwatersplash";
 
+    public BetterWaterSplash() {
+        ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, BetterWaterSplashConfig.serverSpec);
+        FMLJavaModLoadingContext.get().getModEventBus().register(BetterWaterSplashConfig.class);
+    }
+
     @SubscribeEvent
     public static void onProjectileImpactEvent(ProjectileImpactEvent event) {
         //We only want to know when a potion impacts something, not arrows or other entities.
-        if (event.getProjectile().level.isClientSide() || !(event.getProjectile() instanceof ThrownPotion potionEntity)) {
+        if (event.getProjectile().level.isClientSide()
+                || !BetterWaterSplashConfig.SERVER_CONFIG.isDimensionAllowed(event.getProjectile().level.dimension())
+                || !(event.getProjectile() instanceof ThrownPotion potionEntity)) {
             return;
         }
 

--- a/src/main/java/com/suppergerrie2/betterwatersplash/BetterWaterSplashConfig.java
+++ b/src/main/java/com/suppergerrie2/betterwatersplash/BetterWaterSplashConfig.java
@@ -1,0 +1,61 @@
+package com.suppergerrie2.betterwatersplash;
+
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.event.config.ModConfigEvent;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+public class BetterWaterSplashConfig {
+    static final ForgeConfigSpec serverSpec;
+    public static final ServerConfig SERVER_CONFIG;
+
+    static {
+        final Pair<ServerConfig, ForgeConfigSpec> serverPair = new ForgeConfigSpec.Builder().configure(ServerConfig::new);
+        serverSpec = serverPair.getRight();
+        SERVER_CONFIG = serverPair.getLeft();
+    }
+
+    public static class ServerConfig {
+        private final ForgeConfigSpec.ConfigValue<List<? extends String>> listedDimensionsSpec;
+        private final ForgeConfigSpec.BooleanValue isWhitelist;
+        private HashSet<ResourceKey<Level>> listedDimensions;
+
+        ServerConfig(ForgeConfigSpec.Builder builder) {
+            builder.comment("Server configuration settings").push("server");
+            this.listedDimensionsSpec = builder
+                    .comment("A blacklist of dimensions in which splash water bottles extinguish entities",
+                            "Example: [\"minecraft:nether\", \"suppergerrie2:super_cool_dimension\"]",
+                            "Default value: []")
+                    .defineList("blacklistedDimensions", Collections.emptyList(), o -> o instanceof String);
+            this.isWhitelist = builder
+                    .comment("If TRUE, the blacklist will be treated as a whitelist instead",
+                            "Default value: false")
+                    .define("isWhitelist", false);
+        }
+
+        public void onLoadConfig() {
+            listedDimensions = new HashSet<>();
+            for (String dimensionName : listedDimensionsSpec.get()) {
+                listedDimensions.add(ResourceKey.create(Registry.DIMENSION_REGISTRY, new ResourceLocation(dimensionName)));
+            }
+        }
+
+        public boolean isDimensionAllowed(ResourceKey<Level> dimension) {
+            return listedDimensions.contains(dimension) == isWhitelist.get();
+        }
+    }
+
+    @SubscribeEvent
+    public static void onModConfigEvent(final ModConfigEvent event) {
+        if (!event.getConfig().getModId().equals(BetterWaterSplash.MOD_ID)) return;
+        SERVER_CONFIG.onLoadConfig();
+    }
+}


### PR DESCRIPTION
- Add a ServerConfig
- Add a dimension list to the serverconfig
- Add a boolean value to the serverconfig, to determine whether to use the dimension list as a blacklist or as a whitelist
- When config is reloaded, parse the dimension list in the serverconfig to a HashSet for quick checking
- Add a method to the serverconfig to check whether splash water bottles are allowed to extinguish entities in the specified dimension
- In BetterWaterSplash.java#onProjectileImpactEvent, check whether a potion is allowed to extinguish entities in a specific dimension. If not, end handling the event early.

closes #3 